### PR TITLE
ci: Adjust workflow trigger

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,8 +2,10 @@ name: publish-docs
 
 on:
   push:
+    branches:
+      - 'main'
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/publish.yaml'
       - '.vitepress/**'
       - 'src/**'
 


### PR DESCRIPTION
Only run the doc publishing workflow only when pushes on the `main` branch happen.